### PR TITLE
feat(rule): add `allow` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,20 +31,24 @@ textlint --rule max-kanji-continuous-len README.md
 
 ## Options
 
-- `max`
+- `max`: `number`
     - default: 5
+    - 連続できる漢字の文字数
     - `一二三四五六`は6文字なのでエラーとなります。
-    - 最大の漢字長
-    
+- `allow`: `string[]`
+    - default: `[]`
+    - 無視する単語の配列
 
 ```js
 {
     "rules": {
         "max-kanji-continuous-len": {
-            // 最大の漢字長
+            // 連続できる漢字の文字数
             // Allow max continuous length of kanji
             // If {current} > max(5), report Error.
-            max: 5
+            max: 5,
+            // "倍精度浮動小数点数"という単語は例外として無視します
+            allow: ["倍精度浮動小数点数"]
         }
     }
 }

--- a/src/textlint-rule-max-kanji-continuous-len.js
+++ b/src/textlint-rule-max-kanji-continuous-len.js
@@ -5,16 +5,18 @@ import {matchCaptureGroupAll} from "match-index"
 
 const KanjiRegExp = /((?:[々〇〻\u3400-\u9FFF\uF900-\uFAFF]|[\uD840-\uD87F][\uDC00-\uDFFF])+)/g;
 const defaultOptions = {
-    // 最大の漢字連続長
-    // Allow max continuous length of kanji
+    // 連続できる最大の文字数
     // If {current} > max(5), report Error.
-    max: 5
+    max: 5,
+    // 許可する単語のリスト
+    allow: []
 };
 
 module.exports = function reporter(context, options = defaultOptions) {
     const {Syntax, RuleError, report, fixer, getSource} = context;
     const helper = new RuleHelper(context);
     const maxLength = options.max || defaultOptions.max;
+    const allowWords = options.allow || defaultOptions.allow;
     return {
         [Syntax.Str](node){
             if (helper.isChildNode(node, [Syntax.Link, Syntax.Image, Syntax.BlockQuote, Syntax.Emphasis])) {
@@ -22,14 +24,21 @@ module.exports = function reporter(context, options = defaultOptions) {
             }
             const text = getSource(node);
             matchCaptureGroupAll(text, KanjiRegExp).forEach(({text, index}) => {
-                // max より 大きい場合はエラー
-                if (text.length > maxLength) {
+                    // max以下であるなら無視する
+                    if (text.length <= maxLength) {
+                        return;
+                    }
+                    // 辞書にある単語は無視する
+                    if (allowWords.indexOf(text) !== -1) {
+                        return;
+                    }
+                    // maxより長い場合はエラーとなる
                     const ruleError = new RuleError(`漢字が${maxLength + 1}つ以上連続しています: ${text}`, {
                         index
                     });
                     report(node, ruleError);
                 }
-            });
+            );
         }
     }
 };

--- a/test/textlint-rule-max-kanji-continuous-len-test.js
+++ b/test/textlint-rule-max-kanji-continuous-len-test.js
@@ -13,6 +13,13 @@ tester.run("max-kanji-continuous-len", rule, {
             options: {
                 max: 6 // 6 is ok, 7 is ng
             }
+        },
+        {
+            text: "まず倍精度浮動小数点数とは",
+            options: {
+                max: 6,
+                allow: ["倍精度浮動小数点数"]
+            }
         }
     ],
     invalid: [


### PR DESCRIPTION
無視する単語を設定できる `allow` オプションを追加

``` js
{
    "rules": {
        "max-kanji-continuous-len": {
            // 連続できる漢字の文字数
            // Allow max continuous length of kanji
            // If {current} > max(5), report Error.
            max: 5,
            // "倍精度浮動小数点数"という単語は例外として無視します
            allow: ["倍精度浮動小数点数"]
        }
    }
}
```
